### PR TITLE
[YUNIKORN-1256] license issues in deployments examples

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/release-top-level-artifacts/LICENSE
+++ b/release-top-level-artifacts/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/


### PR DESCRIPTION
### What is this PR for?
In the k8shim the tfjob contains files that are not part of Apache. The
LICENSE file should show this. It also should show correctly in the
source release and be merged as part of the release build.

Fixing license issues:
- inconsistent formatting (line endings and empty lines)
- missing license in two k8shim files
- update make target to cover new dile types

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
 https://issues.apache.org/jira/browse/YUNIKORN-1256

### How should this be tested?
build locally and ran all updated make targets
