### PR TITLE
Fix(YUNICORN-1261): Add pre-upgrade hook

### DIFF
--- a/helm-charts/yunikorn/templates/configmap.yaml
+++ b/helm-charts/yunikorn/templates/configmap.yaml
@@ -24,7 +24,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    "helm.sh/hook": "pre-install"
+    "helm.sh/hook": "pre-install, pre-upgrade"
     "helm.sh/hook-weight": "3"
 data:
   queues.yaml: {{quote .Values.configuration}}


### PR DESCRIPTION
I believe `YUNICORN-1261` is caused because we are missing a lifecycle hook for upgrades:

https://helm.sh/docs/topics/charts_hooks/#the-available-hooks