### PR TITLE
[YUNIKORN-1376] update values and deployment helm chart of the admission controller

### DIFF
--- a/helm-charts/yunikorn/templates/admission-controller-deployment.yaml
+++ b/helm-charts/yunikorn/templates/admission-controller-deployment.yaml
@@ -91,6 +91,16 @@ spec:
             value: "{{ .Values.admissionController.labelNamespaces }}"
           - name: ADMISSION_CONTROLLER_NO_LABEL_NAMESPACES
             value: "{{ .Values.admissionController.noLabelNamespaces }}"
+          - name: ADMISSION_CONTROLLER_BYPASS_AUTH
+            value: "{{ .Values.admissionController.bypassAuth }}"
+          - name: ADMISSION_CONTROLLER_TRUST_CONTOLLERS
+            value: "{{ .Values.admissionController.trustControllers }}"
+          - name: ADMISSION_CONTROLLER_SYSTEM_USERS
+            value: "{{ .Values.admissionController.systemUsers }}"
+          - name: ADMISSION_CONTROLLER_EXTERNAL_USERS
+            value: "{{ .Values.admissionController.externalUsers }}"
+          - name: ADMISSION_CONTROLLER_EXTERNAL_GROUPS
+            value: "{{ .Values.admissionController.externalGroups }}"
           - name: SCHEDULER_SERVICE_ADDRESS
             value: "yunikorn-service:9080"
           - name: ENABLE_CONFIG_HOT_REFRESH

--- a/helm-charts/yunikorn/values.yaml
+++ b/helm-charts/yunikorn/values.yaml
@@ -52,6 +52,11 @@ admissionController:
   labelNamespaces: ""
   noLabelNamespaces: ""
   hostNetwork: true
+  bypassAuth: false
+  trustControllers: true
+  systemUsers: "system:serviceaccount:kube-system:*"
+  externalUsers: ""
+  externalGroups: ""
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
New configuration keys have been introduced in YUNIKORN-1322.
These new keys must be reflected in the helm charts so they can be overridden during installation.