### PR TITLE
[YUNIKORN-1541] Fix helm upgrade when host network is enabled

### DIFF
--- a/helm-charts/yunikorn/templates/admission-controller-deployment.yaml
+++ b/helm-charts/yunikorn/templates/admission-controller-deployment.yaml
@@ -26,6 +26,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  {{- if .Values.admissionController.hostNetwork }}
+  strategy:
+    type: Recreate
+  {{- end }}
   replicas: {{ .Values.admissionController.replicaCount }}
   selector:
     matchLabels:

--- a/helm-charts/yunikorn/templates/deployment.yaml
+++ b/helm-charts/yunikorn/templates/deployment.yaml
@@ -24,6 +24,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  {{- if .Values.hostNetwork }}
+  strategy:
+    type: Recreate
+  {{- end }}
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
* When the host network field is set for a deployment, the pods bind to the host port.
* In such a case, if the new pods are scheduled on the same node as the old pods, the default rolling upgrade strategy fails as the host port is unavailable and new pods can't start, because of which old pods can't terminate.
* Use recreate strategy in such cases, so that old pods can terminate and free up the host port for the new pods to start.