### PR TITLE
[YUNIKORN-1577] Fix linespace control on ingress

### DIFF
--- a/helm-charts/yunikorn/templates/ingress.yaml
+++ b/helm-charts/yunikorn/templates/ingress.yaml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{ if .Values.ingress.enabled }}
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -57,4 +57,4 @@ spec:
                   number: {{ .Values.service.portWeb }}
         {{- end }}
   {{- end }}
-{{ end }}
+{{- end }}

--- a/helm-charts/yunikorn/templates/ingress.yaml
+++ b/helm-charts/yunikorn/templates/ingress.yaml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.ingress.enabled -}}
+{{ if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -57,4 +57,4 @@ spec:
                   number: {{ .Values.service.portWeb }}
         {{- end }}
   {{- end }}
-{{- end }}
+{{ end }}


### PR DESCRIPTION
blank line are required otherwise rendering will not produce a valide yaml file for k8s. 

Symptoms: "Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: apiVersion not set" 
Reason: apiVersion is not set on it's own line.