### PR TITLE
[YUNIKORN-1779] Deduplicate the deployment files

### DIFF
--- a/helm-charts/yunikorn/.helmignore
+++ b/helm-charts/yunikorn/.helmignore
@@ -35,3 +35,5 @@
 .project
 .idea/
 *.tmproj
+# script to create files for deployment
+create-deployment-yaml.sh

--- a/helm-charts/yunikorn/create-deployment-yaml.sh
+++ b/helm-charts/yunikorn/create-deployment-yaml.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+mkdir plugin
+mkdir deployment
+helm template yunikorn . -f values.yaml --output-dir ./deployment
+helm template yunikorn ./ -f values.yaml --set enableSchedulerPlugin=true --output-dir ./plugin
+mv ./plugin/yunikorn/templates/deployment.yaml ./deployment/yunikorn/templates/plugin.yaml
+rm -r plugin
+
+folder_path="./deployment/yunikorn/templates"
+target_words=("Helm" "helm" "chart" "annotations" "release")
+
+for file in "$folder_path"/*; do
+  if [ -f "$file" ]; then
+    for word in "${target_words[@]}"; do
+      grep -v "$word" "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+    done
+    mv "$file" "./deployment/"
+  fi
+done
+
+rm -r ./deployment/yunikorn


### PR DESCRIPTION
## Jira ticket
[YUNIKORN-1779](https://issues.apache.org/jira/projects/YUNIKORN/issues/YUNIKORN-1779)

## explanation
Currently, there are two sets of deployment files that are very similar but located in two different projects: `yunikorn-release/helm-charts/yunikorn` and `yunikorn-k8shim/deployments/scheduler`. These files tend to get out of sync.

Considering that there may be situations where raw YAML files are needed instead of using Helm, a script has been added to generate these raw YAML files to provide convenience.

## related PRs
[#679](https://github.com/apache/yunikorn-k8shim/pull/679)
[#350](https://github.com/apache/yunikorn-site/pull/350)