### PR TITLE
[YUNIKORN-2425] Use 'go mod edit' to replace internal module references

### DIFF
--- a/tools/build-release.py
+++ b/tools/build-release.py
@@ -210,12 +210,15 @@ def update_dep_ref_k8shim(local_repo_path):
     mod_file = os.path.join(local_repo_path, "go.mod")
     if not os.path.isfile(mod_file):
         fail("k8shim go.mod does not exist")
-    with open(mod_file, "a") as file_object:
-        file_object.write("\n")
-        file_object.write("replace github.com/apache/yunikorn-core => ../core \n")
-        file_object.write(
-            "replace github.com/apache/yunikorn-scheduler-interface => ../scheduler-interface \n")
-
+    path = os.getcwd()
+    os.chdir(local_repo_path)
+    command = ['go', 'mod', 'edit']
+    command.extend(['-replace', 'github.com/apache/yunikorn-core=../core'])
+    command.extend(['-replace', 'github.com/apache/yunikorn-scheduler-interface=../scheduler-interface'])
+    retcode = subprocess.call(command)
+    if retcode:
+        fail("failed to update k8shim go.mod references")
+    os.chdir(path)
 
 # core depends on scheduler-interface
 def update_dep_ref_core(local_repo_path):
@@ -223,10 +226,14 @@ def update_dep_ref_core(local_repo_path):
     mod_file = os.path.join(local_repo_path, "go.mod")
     if not os.path.isfile(mod_file):
         fail("core go.mod does not exist")
-    with open(mod_file, "a") as file_object:
-        file_object.write("\n")
-        file_object.write(
-            "replace github.com/apache/yunikorn-scheduler-interface => ../scheduler-interface \n")
+    path = os.getcwd()
+    os.chdir(local_repo_path)
+    command = ['go', 'mod', 'edit']
+    command.extend(['-replace', 'github.com/apache/yunikorn-scheduler-interface=../scheduler-interface'])
+    retcode = subprocess.call(command)
+    if retcode:
+        fail("failed to update core go.mod references")
+    os.chdir(path)
 
 
 # update go mod in the repos


### PR DESCRIPTION
### What is this PR for?
Instead of manual file editing, use the go standard tooling to replace references to yunikorn-core and yunikorn-scheduler-interface in go.mod files.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2425

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
