### PR TITLE
[YUNIKORN-2487] Force REPRODUCIBLE_BUILDS=1 when generating release artifacts

### DIFF
--- a/release-top-level-artifacts/README.md
+++ b/release-top-level-artifacts/README.md
@@ -40,7 +40,8 @@ All dependencies are included in the image.
 NOTE: the scheduler can be used without a web UI build or deployed.
 
 ## Building
-Run the `make` command to build docker images.
+Run the `make` command to build docker images. To generate verifiable, reproducible binaries,
+run `make REPRODUCIBLE_BUILDS=1`
 
 ```shell script
 make
@@ -107,6 +108,28 @@ These can be accessed via the [downloads page](https://yunikorn.apache.org/commu
 located in the [User Guide](https://yunikorn.apache.org/docs/).
 
 The convenience build images are multi-architecture images. Supported architectures are `amd64` and `arm64`.
+
+## Reproducible builds
+Building YuniKorn from source generates reproducible build artifacts which
+depend only on the version of YuniKorn built and the go compiler version used.
+
+This release was compiled by the official release manager using Go version `@GO_VERSION@`
+and generated binary artifacts with the following SHA-512 checksums:
+
+### linux/amd64
+```
+@AMD64_BINARIES@
+```
+
+### linux/arm64
+```
+@ARM64_BINARIES@
+```
+
+To verify your own binaries, be sure to execute your build in reproducible mode:
+```shell script
+make REPRODUCIBLE_BUILDS=1
+```
 
 ## Testing the build
 Running the unit tests is supported via the make command.

--- a/tools/build-release.py
+++ b/tools/build-release.py
@@ -265,7 +265,7 @@ def build_web_and_generate_hashes(staging_dir, release_name, arch):
     unpack_staging_tarball(staging_dir, tmp_dir, release_name)
     web_dir = os.path.join(release_dir, "web")
     os.chdir(web_dir)
-    retcode = subprocess.call(['make', 'HOST_ARCH=' + arch, 'build_server_prod'])
+    retcode = subprocess.call(['make', 'REPRODUCIBLE_BUILDS=1', 'HOST_ARCH=' + arch, 'build_server_prod'])
     if retcode:
         fail("failed to build yunikorn-web (%s)" % arch)
     hash = get_checksum("build/prod/yunikorn-web", "yunikorn-web")
@@ -285,7 +285,7 @@ def build_shim_and_generate_hashes(staging_dir, release_name, arch):
     unpack_staging_tarball(staging_dir, tmp_dir, release_name)
     shim_dir = os.path.join(release_dir, "k8shim")
     os.chdir(shim_dir)
-    retcode = subprocess.call(['make', 'HOST_ARCH=' + arch, 'scheduler', 'plugin', 'admission'])
+    retcode = subprocess.call(['make', 'REPRODUCIBLE_BUILDS=1', 'HOST_ARCH=' + arch, 'scheduler', 'plugin', 'admission'])
     if retcode:
         fail("failed to build yunikorn-k8shim (%s)" % arch)
     adm_hash = get_checksum("build/bin/yunikorn-admission-controller", "yunikorn-admission-controller")


### PR DESCRIPTION
### What is this PR for?
Re-enables reproducible build support by forcing a flag which will be read by downstream components.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2487

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
