### PR TITLE
[YUNIKORN-2843] Replace misleading latest tag in Helm chart

### DIFF
--- a/helm-charts/yunikorn/templates/NOTES.txt
+++ b/helm-charts/yunikorn/templates/NOTES.txt
@@ -1,0 +1,5 @@
+YuniKorn components installed with the following image tags:
+- Scheduler:             {{ .Values.image.tag }}
+- Scheduler Plugin:      {{ .Values.pluginImage.tag }}
+- Admission Controller:  {{ .Values.admissionController.image.tag }}
+- Web UI:                {{ .Values.web.image.tag }}

--- a/helm-charts/yunikorn/values.yaml
+++ b/helm-charts/yunikorn/values.yaml
@@ -25,12 +25,12 @@ priorityClassName: ""
 
 image:
   repository: apache/yunikorn
-  tag: scheduler-latest
+  tag: scheduler-{version}
   pullPolicy: Always
 
 pluginImage:
   repository: apache/yunikorn
-  tag: scheduler-plugin-latest
+  tag: scheduler-plugin-{version}
   pullPolicy: Always
 
 nodeSelector: {}
@@ -45,7 +45,7 @@ admissionController:
   priorityClassName: ""
   image:
     repository: apache/yunikorn
-    tag: admission-latest
+    tag: admission-{version}
     pullPolicy: Always
   replicaCount: 1
   serviceAccount: yunikorn-admission-controller
@@ -72,7 +72,7 @@ admissionController:
 web:
   image:
     repository: apache/yunikorn
-    tag: web-latest
+    tag: web-{version}
     pullPolicy: Always
   resources:
     requests:


### PR DESCRIPTION
### What is this PR for?
This proposal aims to reduce friction during installation for new developers.

Currently, when new developers clone the yunikorn-release repository and attempt to `helm install` the charts in `/helm-charts/yunikorn`, they encounter an issue due to the non-existent `latest` tag specified in `values.yaml`.

This misleading configuration could potentially cause confusion and waste time for newcomers trying to troubleshoot the problem.

In a previous PR (https://github.com/apache/yunikorn-site/pull/466), we added information about tag versioning to the Helm Configuration documentation. This update instructs users to find existing tags on Docker Hub for version configuration. The goal of this current change is to provide better guidance for users who might attempt installation without first consulting the official documentation. By implementing this change, we aim to increase the likelihood that users will recognize the need to set the correct tag version, even if they haven't read the updated documentation.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
[YUNIKORN-2843](https://issues.apache.org/jira/browse/YUNIKORN-2843)

### Screenshots (if appropriate)
![image](https://github.com/user-attachments/assets/b1be6bab-c642-49d8-b93f-d5af6f0939f5)

