### PR TITLE
[YUNIKORN-3045] Remove ClusterRole permissions for configmaps

### DIFF
--- a/helm-charts/yunikorn/templates/rbac.yaml
+++ b/helm-charts/yunikorn/templates/rbac.yaml
@@ -34,9 +34,6 @@ metadata:
     "helm.sh/hook-weight": "1"
 rules:
   - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["get", "watch", "list"]
-  - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["scheduling.k8s.io"]


### PR DESCRIPTION

### What is this PR for?
YUNIKORN-2850 scoped ConfigMap watches to just the yunikorn namespace. Remove global access to ConfigMap entries as we no long require it.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-3045

### How should this be tested?
Manual upgrade performed; old permissions removed successfully.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
