### PR TITLE
[YUNIKORN-3440] Use https instead of http in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ limitations under the License.
 This project provides the instructions and tools needed to generate Apache YuniKorn release artifacts.
 Reference:
  - [ASF Release Creation Process](https://infra.apache.org/release-publishing.html)
- - [ASF Release Policy](http://www.apache.org/legal/release-policy.html).
+ - [ASF Release Policy](https://www.apache.org/legal/release-policy.html).
 
 # Release Procedure
 A simplified procedure: 


### PR DESCRIPTION
### Description
Update the link in the README to use https instead of http.

Generated by Claude (commit message and PR description wording; the file changes were made and verified by me)

### Type of change

- [x] Improvement

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3440

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [x] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.


Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [ ] `make test_all` was run, and no failures reported.

Documentation-only change; no code paths affected. The updated link was verified to resolve over https.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A
