### PR TITLE
[YUNIKORN-3444] merge_pr.sh: tail +2 fails on GNU tail

### DIFF
--- a/release-tools/merge_pr.sh
+++ b/release-tools/merge_pr.sh
@@ -112,7 +112,7 @@ function create_body() {
   for i in $(git rev-list HEAD.."${PRBRANCH}" --reverse); do
     git log -1 --pretty=format:"%s%n%b" "$i" >> "${BODYFILE}"
   done
-  BODY=$(tail +2 "${BODYFILE}")
+  BODY=$(tail -n +2 "${BODYFILE}")
   rm "${BODYFILE}"
 }
 


### PR DESCRIPTION
### Description
In `release-tools/merge_pr.sh`, `create_body()` invokes `tail +2 "${BODYFILE}"` to extract the commit body starting from line 2.
On Linux environments with GNU coreutils (e.g. Fedora, Ubuntu), arguments not starting with `-` are treated as file operands per POSIX.1-2001, causing `tail` to attempt opening a file named `+2` and failing with:
```
tail: cannot open '+2' for reading: No such file or directory
```
This PR switches to the POSIX-compliant `tail -n +2 "${BODYFILE}"`, which is fully portable across macOS (BSD coreutils), Linux (GNU coreutils / BusyBox), and Windows Git Bash.

### Type of change
- [x] Bug Fix
- [ ] Improvement
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3444

- [ ] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
If an AI tool was used:
- [x] The PR includes the phrase "Generated by Antigravity CLI", where Antigravity CLI is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How has this been tested?
- [x] Verified `bash -n release-tools/merge_pr.sh` passes without errors.
- [x] Simulated `create_body` logic confirming line 1 is stripped and subsequent lines are preserved without GNU tail operand errors.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.
