### PR TITLE
[YUNIKORN-3444] Fix tail syntax in merge script

### DIFF
--- a/release-tools/merge_pr.sh
+++ b/release-tools/merge_pr.sh
@@ -112,7 +112,7 @@ function create_body() {
   for i in $(git rev-list HEAD.."${PRBRANCH}" --reverse); do
     git log -1 --pretty=format:"%s%n%b" "$i" >> "${BODYFILE}"
   done
-  BODY=$(tail +2 "${BODYFILE}")
+  BODY=$(tail -n +2 "${BODYFILE}")
   rm "${BODYFILE}"
 }
 


### PR DESCRIPTION
Use tail -n +2 to skip the first line portably on GNU and BSD tail.

Validation: bash -n, git diff --check, and five local tail input cases passed.

### Description
Use tail -n +2 to skip the first line portably on GNU and BSD tail.

### Type of change
- [x] Bug Fix

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3444
- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
- [ ] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy.

### How has this been tested?
- [ ] New unit tests were added to cover new or changed code paths.
- [ ] `make test_all` was run, and no failures reported.

### Questions:
- [ ] The change needs documentation, a pull request for apache/yunikorn-site repository will be created.
- [ ] There is breaking changes for older versions: jira is tagged with `release-notes` label.
- [ ] The licenses files needs to be updated.

### Screenshots or other details
N/A
